### PR TITLE
Dsr 649 branch

### DIFF
--- a/additional/cyclic.c
+++ b/additional/cyclic.c
@@ -16,7 +16,6 @@ static void ec_sync(int64 reftime, int64 cycletime , int64 *offsettime)
   if(delta>0){ integral++; }
   if(delta<0){ integral--; }
   *offsettime = -(delta / 100) - (integral / 20);
-  gl_delta = delta;
 }
 
 static void add_timespec(struct timespec *ts_, int64 addtime)

--- a/additional/cyclic.c
+++ b/additional/cyclic.c
@@ -19,8 +19,6 @@ static void ec_sync(int64 reftime, int64 cycletime , int64 *offsettime)
   gl_delta = delta;
 }
 
-
-
 static void add_timespec(struct timespec *ts_, int64 addtime)
 {
   int64 sec, nsec;

--- a/additional/cyclic.h
+++ b/additional/cyclic.h
@@ -22,7 +22,7 @@
 
 int64 gl_delta;
 
-void initialise_cyclic_variables();
+void initialise_cyclic_variables(void);
 void sleep_cycle_with_offset(int64_t cycletime);
 void sleep_cycle(int64_t sleep);
 void calc_offset(int64_t cycletime);

--- a/additional/cyclic.h
+++ b/additional/cyclic.h
@@ -19,13 +19,9 @@
 
 #define NSEC_PER_SEC 1000000000
 
-
-int64 gl_delta;
-
 void initialise_cyclic_variables(void);
 void sleep_cycle_with_offset(int64_t cycletime);
 void sleep_cycle(int64_t sleep);
 void calc_offset(int64_t cycletime);
-
 
 #endif

--- a/osal/linux/osal.c
+++ b/osal/linux/osal.c
@@ -12,6 +12,8 @@
 
 #define USECS_PER_SEC     1000000
 
+static int osal_gettimeofday(struct timeval *tv, struct timezone *tz);
+
 int osal_usleep (uint32 usec)
 {
    struct timespec ts;
@@ -21,7 +23,7 @@ int osal_usleep (uint32 usec)
    return nanosleep(&ts, NULL);
 }
 
-int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
+static int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
    struct timespec ts;
    int return_value;
@@ -88,7 +90,7 @@ boolean osal_timer_is_expired (osal_timert * self)
 
    return is_not_yet_expired == FALSE;
 }
-
+#if 0
 void *osal_malloc(size_t size)
 {
    return malloc(size);
@@ -98,7 +100,7 @@ void osal_free(void *ptr)
 {
    free(ptr);
 }
-
+#endif
 int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
 {
    int                  ret;

--- a/osal/linux/osal.c
+++ b/osal/linux/osal.c
@@ -11,9 +11,9 @@
 #include <osal.h>
 
 #define USECS_PER_SEC     1000000
-#define XRT_CHANGES
+#define STACK_CHANGES
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz);
 #endif
 
@@ -25,7 +25,7 @@ int osal_usleep (uint32 usec)
    /* usleep is deprecated, use nanosleep instead */
    return nanosleep(&ts, NULL);
 }
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
    struct timespec ts;
@@ -110,7 +110,7 @@ boolean osal_timer_is_expired (osal_timert * self)
 
    return is_not_yet_expired == FALSE;
 }
-#ifndef XRT_CHANGES
+#ifndef STACK_CHANGES
 void *osal_malloc(size_t size)
 {
    return malloc(size);

--- a/osal/linux/osal.c
+++ b/osal/linux/osal.c
@@ -11,8 +11,9 @@
 #include <osal.h>
 
 #define USECS_PER_SEC     1000000
+#define XRT_CHANGES
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz);
 #endif
 
@@ -24,7 +25,7 @@ int osal_usleep (uint32 usec)
    /* usleep is deprecated, use nanosleep instead */
    return nanosleep(&ts, NULL);
 }
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
    struct timespec ts;
@@ -109,7 +110,7 @@ boolean osal_timer_is_expired (osal_timert * self)
 
    return is_not_yet_expired == FALSE;
 }
-#ifndef DECLARATION_CHANGES
+#ifndef XRT_CHANGES
 void *osal_malloc(size_t size)
 {
    return malloc(size);

--- a/osal/linux/osal.c
+++ b/osal/linux/osal.c
@@ -12,7 +12,9 @@
 
 #define USECS_PER_SEC     1000000
 
+#ifdef DECLARATION_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz);
+#endif
 
 int osal_usleep (uint32 usec)
 {
@@ -22,7 +24,7 @@ int osal_usleep (uint32 usec)
    /* usleep is deprecated, use nanosleep instead */
    return nanosleep(&ts, NULL);
 }
-
+#ifdef DECLARATION_CHANGES
 static int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
    struct timespec ts;
@@ -38,6 +40,23 @@ static int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
    tv->tv_usec = ts.tv_nsec / 1000;
    return return_value;
 }
+#else
+int osal_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+   struct timespec ts;
+   int return_value;
+   (void)tz;       /* Not used */
+
+   /* Use clock_gettime to prevent possible live-lock.
+    * Gettimeofday uses CLOCK_REALTIME that can get NTP timeadjust.
+    * If this function preempts timeadjust and it uses vpage it live-locks.
+    * Also when using XENOMAI, only clock_gettime is RT safe */
+   return_value = clock_gettime(CLOCK_MONOTONIC, &ts);
+   tv->tv_sec = ts.tv_sec;
+   tv->tv_usec = ts.tv_nsec / 1000;
+   return return_value;
+}
+#endif
 
 ec_timet osal_current_time(void)
 {
@@ -90,7 +109,7 @@ boolean osal_timer_is_expired (osal_timert * self)
 
    return is_not_yet_expired == FALSE;
 }
-#if 0
+#ifndef DECLARATION_CHANGES
 void *osal_malloc(size_t size)
 {
    return malloc(size);

--- a/osal/osal.h
+++ b/osal/osal.h
@@ -14,6 +14,8 @@ extern "C"
 #include "osal_defs.h"
 #include <stdint.h>
 
+#define DECLARATION_CHANGES
+
 /* General types */
 #ifndef TRUE
 #define TRUE                1

--- a/osal/osal.h
+++ b/osal/osal.h
@@ -14,7 +14,7 @@ extern "C"
 #include "osal_defs.h"
 #include <stdint.h>
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 /* General types */
 #ifndef TRUE

--- a/osal/osal.h
+++ b/osal/osal.h
@@ -14,7 +14,7 @@ extern "C"
 #include "osal_defs.h"
 #include <stdint.h>
 
-#define DECLARATION_CHANGES
+#define XRT_CHANGES
 
 /* General types */
 #ifndef TRUE

--- a/oshw/linux/nicdrv.c
+++ b/oshw/linux/nicdrv.c
@@ -188,13 +188,16 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
 int ecx_closenic(ecx_portt *port)
 {
    if (port->sockhandle >= 0)
-      pthread_mutex_destroy(&(port->getindex_mutex));
-      pthread_mutex_destroy(&(port->tx_mutex));
-      pthread_mutex_destroy(&(port->rx_mutex));
-      close(port->sockhandle);
+   {
+     pthread_mutex_destroy(&(port->getindex_mutex));
+     pthread_mutex_destroy(&(port->tx_mutex));
+     pthread_mutex_destroy(&(port->rx_mutex));
+     close(port->sockhandle);
+   }
    if ((port->redport) && (port->redport->sockhandle >= 0))
-      close(port->redport->sockhandle);
-
+   {
+     close(port->redport->sockhandle);
+   }
    return 0;
 }
 
@@ -648,3 +651,4 @@ int ec_srconfirm(int idx, int timeout)
    return ecx_srconfirm(&ecx_port, idx, timeout);
 }
 #endif
+

--- a/oshw/linux/nicdrv.h
+++ b/oshw/linux/nicdrv.h
@@ -112,10 +112,12 @@ int ecx_outframe(ecx_portt *port, int idx, int sock);
 int ecx_outframe_red(ecx_portt *port, int idx);
 int ecx_waitinframe(ecx_portt *port, int idx, int timeout);
 int ecx_srconfirm(ecx_portt *port, int idx,int timeout);
-////
+
+#ifdef DECLARATION_CHANGES
 int ecx_inframe(ecx_portt *port, int idx, int stacknumber);
 int ec_inframe(int idx, int stacknumber);
-////
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/oshw/linux/nicdrv.h
+++ b/oshw/linux/nicdrv.h
@@ -17,7 +17,7 @@ extern "C"
 #endif
 
 #include <pthread.h>
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 /** pointer structure to Tx and Rx stacks */
 typedef struct
@@ -114,7 +114,7 @@ int ecx_outframe_red(ecx_portt *port, int idx);
 int ecx_waitinframe(ecx_portt *port, int idx, int timeout);
 int ecx_srconfirm(ecx_portt *port, int idx,int timeout);
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 int ecx_inframe(ecx_portt *port, int idx, int stacknumber);
 int ec_inframe(int idx, int stacknumber);
 #endif

--- a/oshw/linux/nicdrv.h
+++ b/oshw/linux/nicdrv.h
@@ -112,7 +112,10 @@ int ecx_outframe(ecx_portt *port, int idx, int sock);
 int ecx_outframe_red(ecx_portt *port, int idx);
 int ecx_waitinframe(ecx_portt *port, int idx, int timeout);
 int ecx_srconfirm(ecx_portt *port, int idx,int timeout);
-
+////
+int ecx_inframe(ecx_portt *port, int idx, int stacknumber);
+int ec_inframe(int idx, int stacknumber);
+////
 #ifdef __cplusplus
 }
 #endif

--- a/oshw/linux/nicdrv.h
+++ b/oshw/linux/nicdrv.h
@@ -17,6 +17,7 @@ extern "C"
 #endif
 
 #include <pthread.h>
+#define XRT_CHANGES
 
 /** pointer structure to Tx and Rx stacks */
 typedef struct
@@ -113,7 +114,7 @@ int ecx_outframe_red(ecx_portt *port, int idx);
 int ecx_waitinframe(ecx_portt *port, int idx, int timeout);
 int ecx_srconfirm(ecx_portt *port, int idx,int timeout);
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 int ecx_inframe(ecx_portt *port, int idx, int stacknumber);
 int ec_inframe(int idx, int stacknumber);
 #endif

--- a/oshw/linux/oshw.c
+++ b/oshw/linux/oshw.c
@@ -80,7 +80,11 @@ ec_adaptert * oshw_find_adapters(void)
           {
              string_len = EC_MAXLEN_ADAPTERNAME - 1;
           }
+#ifdef DECLARATION_CHANGES
+          memcpy(adapter->name, ids[i].if_name, string_len);
+#else
           strncpy(adapter->name, ids[i].if_name,string_len);
+#endif
           adapter->name[string_len] = '\0';
           strncpy(adapter->desc, ids[i].if_name,string_len);
           adapter->desc[string_len] = '\0';

--- a/oshw/linux/oshw.c
+++ b/oshw/linux/oshw.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "oshw.h"
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 /**
  * Host to Network byte order (i.e. to big endian).
@@ -82,7 +82,7 @@ ec_adaptert * oshw_find_adapters(void)
           {
              string_len = EC_MAXLEN_ADAPTERNAME - 1;
           }
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
           memcpy(adapter->name, ids[i].if_name, string_len);
 #else
           strncpy(adapter->name, ids[i].if_name,string_len);

--- a/oshw/linux/oshw.c
+++ b/oshw/linux/oshw.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include "oshw.h"
 
+#define XRT_CHANGES
+
 /**
  * Host to Network byte order (i.e. to big endian).
  *
@@ -80,7 +82,7 @@ ec_adaptert * oshw_find_adapters(void)
           {
              string_len = EC_MAXLEN_ADAPTERNAME - 1;
           }
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
           memcpy(adapter->name, ids[i].if_name, string_len);
 #else
           strncpy(adapter->name, ids[i].if_name,string_len);

--- a/soem/ethercatcoe.c
+++ b/soem/ethercatcoe.c
@@ -1503,3 +1503,4 @@ int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist)
    return ecx_readOE(&ecx_context, Item, pODlist, pOElist);
 }
 #endif
+

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 /** max entries in Object Description list */
 #define EC_MAXODLIST   1024
@@ -75,7 +75,7 @@ int ec_readODdescription(uint16 Item, ec_ODlistt *pODlist);
 int ec_readOEsingle(uint16 Item, uint8 SubI, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 int ec_readPDOassign(uint16 Slave, uint16 PDOassign);
 int ecx_readPDOassign(ecx_contextt *context, uint16 Slave, uint16 PDOassign);
 int ec_readPDOassignCA(uint16 Slave, uint16 PDOassign, int Thread_n);

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -72,6 +72,12 @@ int ec_readODlist(uint16 Slave, ec_ODlistt *pODlist);
 int ec_readODdescription(uint16 Item, ec_ODlistt *pODlist);
 int ec_readOEsingle(uint16 Item, uint8 SubI, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
+
+/////////
+int ecx_readPDOassign(ecx_contextt *context, uint16 Slave, uint16 PDOassign);
+int ec_readPDOassignCA(uint16 Slave, uint16 PDOassign, int Thread_n);
+
+/////////
 #endif
 
 void ecx_SDOerror(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIdx, int32 AbortCode);

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -73,7 +73,7 @@ int ec_readODdescription(uint16 Item, ec_ODlistt *pODlist);
 int ec_readOEsingle(uint16 Item, uint8 SubI, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 int ec_readPDOassign(uint16 Slave, uint16 PDOassign);
 int ecx_readPDOassign(ecx_contextt *context, uint16 Slave, uint16 PDOassign);
 int ec_readPDOassignCA(uint16 Slave, uint16 PDOassign, int Thread_n);

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -73,11 +73,13 @@ int ec_readODdescription(uint16 Item, ec_ODlistt *pODlist);
 int ec_readOEsingle(uint16 Item, uint8 SubI, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 
-/////////
+#ifdef DECLARATION_CHANGES
+int ec_readPDOassign(uint16 Slave, uint16 PDOassign);
 int ecx_readPDOassign(ecx_contextt *context, uint16 Slave, uint16 PDOassign);
 int ec_readPDOassignCA(uint16 Slave, uint16 PDOassign, int Thread_n);
+int ecx_readPDOassignCA(ecx_contextt *context, uint16 Slave, int Thread_n);
+#endif
 
-/////////
 #endif
 
 void ecx_SDOerror(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIdx, int32 AbortCode);

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -16,6 +16,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 /** max entries in Object Description list */
 #define EC_MAXODLIST   1024
 

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -77,7 +77,7 @@ int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 int ec_readPDOassign(uint16 Slave, uint16 PDOassign);
 int ecx_readPDOassign(ecx_contextt *context, uint16 Slave, uint16 PDOassign);
 int ec_readPDOassignCA(uint16 Slave, uint16 PDOassign, int Thread_n);
-int ecx_readPDOassignCA(ecx_contextt *context, uint16 Slave, int Thread_n);
+int ecx_readPDOassignCA(ecx_contextt *context, uint16 Slave, int Thread_n, uint16 PDOassign);
 #endif
 
 #endif

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -22,7 +22,7 @@
 #include "ethercatsoe.h"
 #include "ethercatconfig.h"
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 typedef struct
 {
@@ -365,7 +365,7 @@ int ecx_config_init(ecx_contextt *context, uint8 usetable)
          context->slavelist[slave].eep_id = etohl(eedat);
          ecx_readeeprom1(context, slave, ECT_SII_REV); /* revision */
       }
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
      for (slave = 1; slave <= *(context->slavecount); slave++)
      {
        eedat = ecx_readeeprom2(context, slave, EC_TIMEOUTEEP); /* ID */

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -364,6 +364,14 @@ int ecx_config_init(ecx_contextt *context, uint8 usetable)
          context->slavelist[slave].eep_id = etohl(eedat);
          ecx_readeeprom1(context, slave, ECT_SII_REV); /* revision */
       }
+#ifdef XRT_CHANGES
+     for (slave = 1; slave <= *(context->slavecount); slave++)
+     {
+       eedat = ecx_readeeprom2(context, slave, EC_TIMEOUTEEP); /* ID */
+       context->slavelist[slave].eep_sn = etohl(eedat);
+       ecx_readeeprom1(context, slave, ECT_SII_SN); /* serial number */
+     }
+#endif
       for (slave = 1; slave <= *(context->slavecount); slave++)
       {
          eedat = ecx_readeeprom2(context, slave, EC_TIMEOUTEEP); /* revision */

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -22,6 +22,7 @@
 #include "ethercatsoe.h"
 #include "ethercatconfig.h"
 
+#define XRT_CHANGES
 
 typedef struct
 {

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -16,6 +16,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 #define EC_NODEOFFSET      0x1000
 #define EC_TEMPNODE        0xffff
 

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -29,6 +29,13 @@ int ec_config(uint8 usetable, void *pIOmap);
 int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
 int ec_reconfig_slave(uint16 slave, int timeout);
+
+////////////
+int ec_findconfig( uint32 man, uint32 id);
+void ecx_init_context(ecx_contextt *context);
+int ecx_detect_slaves(ecx_contextt *context);
+
+////////////
 #endif
 
 int ecx_config_init(ecx_contextt *context, uint8 usetable);

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -30,7 +30,7 @@ int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
 int ec_reconfig_slave(uint16 slave, int timeout);
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 int ec_findconfig( uint32 man, uint32 id);
 void ecx_init_context(ecx_contextt *context);
 int ecx_detect_slaves(ecx_contextt *context);

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -30,12 +30,12 @@ int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
 int ec_reconfig_slave(uint16 slave, int timeout);
 
-////////////
+#ifdef DECLARATION_CHANGES
 int ec_findconfig( uint32 man, uint32 id);
 void ecx_init_context(ecx_contextt *context);
 int ecx_detect_slaves(ecx_contextt *context);
+#endif
 
-////////////
 #endif
 
 int ecx_config_init(ecx_contextt *context, uint8 usetable);

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 #define EC_NODEOFFSET      0x1000
 #define EC_TEMPNODE        0xffff
@@ -32,7 +32,7 @@ int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
 int ec_reconfig_slave(uint16 slave, int timeout);
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 int ec_findconfig( uint32 man, uint32 id);
 void ecx_init_context(ecx_contextt *context);
 int ecx_detect_slaves(ecx_contextt *context);

--- a/soem/ethercatdc.h
+++ b/soem/ethercatdc.h
@@ -17,7 +17,7 @@ extern "C"
 #endif
 
 #ifdef EC_VER1
-boolean ec_configdc();
+boolean ec_configdc(void);
 void ec_dcsync0(uint16 slave, boolean act, uint32 CyclTime, int32 CyclShift);
 void ec_dcsync01(uint16 slave, boolean act, uint32 CyclTime0, uint32 CyclTime1, int32 CyclShift);
 #endif

--- a/soem/ethercatdc.h
+++ b/soem/ethercatdc.h
@@ -17,7 +17,7 @@ extern "C"
 #endif
 
 #ifdef EC_VER1
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 boolean ec_configdc(void);
 #else
 boolean ec_configdc();

--- a/soem/ethercatdc.h
+++ b/soem/ethercatdc.h
@@ -16,6 +16,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 #ifdef EC_VER1
 #ifdef XRT_CHANGES
 boolean ec_configdc(void);

--- a/soem/ethercatdc.h
+++ b/soem/ethercatdc.h
@@ -17,7 +17,11 @@ extern "C"
 #endif
 
 #ifdef EC_VER1
+#ifdef DECLARATION_CHANGES
 boolean ec_configdc(void);
+#else
+boolean ec_configdc();
+#endif
 void ec_dcsync0(uint16 slave, boolean act, uint32 CyclTime, int32 CyclShift);
 void ec_dcsync01(uint16 slave, boolean act, uint32 CyclTime0, uint32 CyclTime1, int32 CyclShift);
 #endif

--- a/soem/ethercatdc.h
+++ b/soem/ethercatdc.h
@@ -16,10 +16,10 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 #ifdef EC_VER1
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 boolean ec_configdc(void);
 #else
 boolean ec_configdc();

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -524,6 +524,14 @@ int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
 int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
 
+/////////
+int ecx_FPRD_multi(ecx_contextt *context, int n, uint16 *configlst, ec_alstatust *slstatlst, int timeout);
+uint16 ecx_eeprom_waitnotbusyAP(ecx_contextt *context, uint16 aiadr,uint16 *estat, int timeout);
+uint16 ecx_eeprom_waitnotbusyFP(ecx_contextt *context, uint16 configadr,uint16 *estat, int timeout);
+uint16 ec_eeprom_waitnotbusyAP(uint16 aiadr,uint16 *estat, int timeout);
+uint16 ec_eeprom_waitnotbusyFP(uint16 configadr,uint16 *estat, int timeout);
+///////
+
 #ifdef __cplusplus
 }
 #endif

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -17,6 +17,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 /** max. entries in EtherCAT error list */
 #define EC_MAXELIST       64
 /** max. length of readable name in slavelist and Object Description List */

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -17,7 +17,7 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 /** max. entries in EtherCAT error list */
 #define EC_MAXELIST       64
@@ -121,7 +121,7 @@ typedef struct ec_slave
    uint32           eep_id;
    /** revision from EEprom */
    uint32           eep_rev;
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
    /** serial number */
    uint32           eep_sn;
 #endif
@@ -530,7 +530,7 @@ int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
 int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 int ecx_FPRD_multi(ecx_contextt *context, int n, uint16 *configlst, ec_alstatust *slstatlst, int timeout);
 uint16 ecx_eeprom_waitnotbusyAP(ecx_contextt *context, uint16 aiadr,uint16 *estat, int timeout);
 uint16 ecx_eeprom_waitnotbusyFP(ecx_contextt *context, uint16 configadr,uint16 *estat, int timeout);

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -524,13 +524,13 @@ int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
 int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
 
-/////////
+#ifdef DECLARATION_CHANGES
 int ecx_FPRD_multi(ecx_contextt *context, int n, uint16 *configlst, ec_alstatust *slstatlst, int timeout);
 uint16 ecx_eeprom_waitnotbusyAP(ecx_contextt *context, uint16 aiadr,uint16 *estat, int timeout);
 uint16 ecx_eeprom_waitnotbusyFP(ecx_contextt *context, uint16 configadr,uint16 *estat, int timeout);
 uint16 ec_eeprom_waitnotbusyAP(uint16 aiadr,uint16 *estat, int timeout);
 uint16 ec_eeprom_waitnotbusyFP(uint16 configadr,uint16 *estat, int timeout);
-///////
+#endif
 
 #ifdef __cplusplus
 }

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -119,6 +119,10 @@ typedef struct ec_slave
    uint32           eep_id;
    /** revision from EEprom */
    uint32           eep_rev;
+#ifdef XRT_CHANGES
+   /** serial number */
+   uint32           eep_sn;
+#endif
    /** Interface type */
    uint16           Itype;
    /** Device type */
@@ -524,7 +528,7 @@ int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
 int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 int ecx_FPRD_multi(ecx_contextt *context, int n, uint16 *configlst, ec_alstatust *slstatlst, int timeout);
 uint16 ecx_eeprom_waitnotbusyAP(ecx_contextt *context, uint16 aiadr,uint16 *estat, int timeout);
 uint16 ecx_eeprom_waitnotbusyFP(ecx_contextt *context, uint16 configadr,uint16 *estat, int timeout);

--- a/soem/ethercatprint.c
+++ b/soem/ethercatprint.c
@@ -16,6 +16,7 @@
 #include "oshw.h"
 #include "ethercattype.h"
 #include "ethercatmain.h"
+#include "ethercatprint.h"
 
 #define EC_MAXERRORNAME 127
 

--- a/soem/ethercatprint.h
+++ b/soem/ethercatprint.h
@@ -16,6 +16,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 #ifdef XRT_CHANGES
 const char* ec_sdoerror2string( uint32 sdoerrorcode);
 #else

--- a/soem/ethercatprint.h
+++ b/soem/ethercatprint.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 const char* ec_sdoerror2string( uint32 sdoerrorcode);
 #else
 char* ec_sdoerror2string( uint32 sdoerrorcode);

--- a/soem/ethercatprint.h
+++ b/soem/ethercatprint.h
@@ -16,9 +16,9 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 const char* ec_sdoerror2string( uint32 sdoerrorcode);
 #else
 char* ec_sdoerror2string( uint32 sdoerrorcode);

--- a/soem/ethercatprint.h
+++ b/soem/ethercatprint.h
@@ -16,7 +16,11 @@ extern "C"
 {
 #endif
 
+#ifdef DECLARATION_CHANGES
 const char* ec_sdoerror2string( uint32 sdoerrorcode);
+#else
+char* ec_sdoerror2string( uint32 sdoerrorcode);
+#endif
 char* ec_ALstatuscode2string( uint16 ALstatuscode);
 char* ec_soeerror2string( uint16 errorcode);
 char* ec_mbxerror2string( uint16 errorcode);

--- a/soem/ethercatprint.h
+++ b/soem/ethercatprint.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-char* ec_sdoerror2string( uint32 sdoerrorcode);
+const char* ec_sdoerror2string( uint32 sdoerrorcode);
 char* ec_ALstatuscode2string( uint16 ALstatuscode);
 char* ec_soeerror2string( uint16 errorcode);
 char* ec_mbxerror2string( uint16 errorcode);

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -123,9 +123,10 @@ int ecx_SoEread(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elemen
 int ecx_SoEwrite(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elementflags, uint16 idn, int psize, void *p, int timeout);
 int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize);
 
-//////////
+#ifdef DECLARATION_CHANGES
 void ecx_SoEerror(ecx_contextt *context, uint16 Slave, uint16 idn, uint16 Error);
-/////////
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 #define EC_SOE_DATASTATE_B   0x01
 #define EC_SOE_NAME_B        0x02
@@ -125,7 +125,7 @@ int ecx_SoEread(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elemen
 int ecx_SoEwrite(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elementflags, uint16 idn, int psize, void *p, int timeout);
 int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize);
 
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
 void ecx_SoEerror(ecx_contextt *context, uint16 Slave, uint16 idn, uint16 Error);
 #endif
 

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -16,6 +16,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 #define EC_SOE_DATASTATE_B   0x01
 #define EC_SOE_NAME_B        0x02
 #define EC_SOE_ATTRIBUTE_B   0x04

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -123,6 +123,9 @@ int ecx_SoEread(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elemen
 int ecx_SoEwrite(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elementflags, uint16 idn, int psize, void *p, int timeout);
 int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize);
 
+//////////
+void ecx_SoEerror(ecx_contextt *context, uint16 Slave, uint16 idn, uint16 Error);
+/////////
 #ifdef __cplusplus
 }
 #endif

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -123,7 +123,7 @@ int ecx_SoEread(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elemen
 int ecx_SoEwrite(ecx_contextt *context, uint16 slave, uint8 driveNo, uint8 elementflags, uint16 idn, int psize, void *p, int timeout);
 int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize);
 
-#ifdef DECLARATION_CHANGES
+#ifdef XRT_CHANGES
 void ecx_SoEerror(ecx_contextt *context, uint16 Slave, uint16 idn, uint16 Error);
 #endif
 

--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -292,7 +292,8 @@ enum
    /** SII category SM */
    ECT_SII_SM          = 41,
    /** SII category PDO */
-   ECT_SII_PDO         = 50
+   ECT_SII_PDO         = 50,
+   /** SII catergory serial*/
 };
 
 /** Item offsets in SII general section */
@@ -306,7 +307,10 @@ enum
    ECT_SII_MBXSIZE     = 0x0019,
    ECT_SII_TXMBXADR    = 0x001a,
    ECT_SII_RXMBXADR    = 0x0018,
-   ECT_SII_MBXPROTO    = 0x001c
+   ECT_SII_MBXPROTO    = 0x001c,
+#ifdef XRT_CHANGES
+   ECT_SII_SN          = 0x000e
+#endif
 };
 
 /** Mailbox types definitions */

--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -23,7 +23,7 @@ extern "C"
 {
 #endif
 
-#define XRT_CHANGES
+#define STACK_CHANGES
 
 #include "osal.h"
 
@@ -310,7 +310,7 @@ enum
    ECT_SII_TXMBXADR    = 0x001a,
    ECT_SII_RXMBXADR    = 0x0018,
    ECT_SII_MBXPROTO    = 0x001c,
-#ifdef XRT_CHANGES
+#ifdef STACK_CHANGES
    ECT_SII_SN          = 0x000e
 #endif
 };

--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -23,6 +23,8 @@ extern "C"
 {
 #endif
 
+#define XRT_CHANGES
+
 #include "osal.h"
 
 /** define EC_VER1 if version 1 default context and functions are needed


### PR DESCRIPTION
Changes made as there were many compiler warnings about undefined prototypes within the stack. Changes are easily reversible with the STACK_CHANGES definition. Also added ability to read the serial number of a device via eeprom.